### PR TITLE
[PERF-2336] Provide public documentation for GTM

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.teads.com"
-documentation: "https://support.teads.tv/support/solutions/articles/36000224363-introduction-to-events-management"
+documentation: "https://help.teads.com/en/collections/3221002-teads-universal-pixel"
 versions:
   # Latest version
   - sha: 6eb7ec152ea133fd8e84859c161f66d5c84a4d4e


### PR DESCRIPTION
According to https://teads.slack.com/archives/C1C7ZCJKX/p1635863638049300 we need to provide a public documentation for GTM. Our current documentation https://support.teads.tv/support/solutions/articles/36000224364 was private and not only dedicated to GTM. It is replaced here by our new public documentation.